### PR TITLE
Remove external dependencies and reorganized examples

### DIFF
--- a/examples/SimpleButton/SimpleButtonBricktronicsBreakoutBoard/SimpleButtonBricktronicsBreakoutBoard.ino
+++ b/examples/SimpleButton/SimpleButtonBricktronicsBreakoutBoard/SimpleButtonBricktronicsBreakoutBoard.ino
@@ -1,21 +1,17 @@
-// Bricktronics Example: SimpleButtonBricktronicsShield
+// Bricktronics Example: SimpleButtonBricktronicsBreakoutBoard
 // http://www.wayneandlayne.com/bricktronics
 //
 // This example queries the NXT pushbutton sensor and transmits "pressed" and
 // "released" over the serial port.
 //
 // Hardware used:
-// * Wayne and Layne Bricktronics Shield
-//   https://store.wayneandlayne.com/products/bricktronics-shield-kit.html
+// * Wayne and Layne Bricktronics Breakout Board
+//   https://store.wayneandlayne.com/products/bricktronics-breakout-board.html
 // * LEGO NXT Pushbutton sensor
 //
 // Software libraries used:
 // * Wayne and Layne BricktronicsButton library
 //   https://github.com/wayneandlayne/BricktronicsButton
-// * Wayne and Layne BricktronicsShield library
-//   https://github.com/wayneandlayne/BricktronicsShield
-// * Adafruit MCP23017 library
-//   https://github.com/adafruit/Adafruit-MCP23017-Arduino-Library
 //
 // Written in 2016 by Matthew Beckler and Adam Wolf for Wayne and Layne, LLC
 // To the extent possible under law, the author(s) have dedicated all
@@ -25,28 +21,28 @@
 //   with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 
-// Include software libraries
-#include <Wire.h>
-#include <Adafruit_MCP23017.h>
-
-
 // Include the Bricktronics libraries
 #include <BricktronicsButton.h>
-#include <BricktronicsShield.h>
 
 
-// Select the sensor port (SENSOR_1 through SENSOR_4) in the constructor below.
-// If your chosen sensor port has jumpers (ports 3 and 4), connect pins 2-3 and 4-5.
-BricktronicsButton b(BricktronicsShield::SENSOR_1);
+// Connect these pins on the Bricktronics Breakout board:
+//  Pin 1 - Connect to Arduino input pin (any digital input pin)
+//  Pin 2 - Connect to Ground
+//  Pin 3 - Connect to Ground
+//  Pin 4 - Connect to 5V
+//  Pin 5 - No connection
+//  Pin 6 - No connection
+//
+// The BricktronicsButton() argument is simply the Arduino pin where pin 1
+// on the breakout board is connected.
+//
+BricktronicsButton b(7);
 
 
 void setup()
 {
   // Be sure to set your serial console to 115200 baud
   Serial.begin(115200);
-
-  // Initialize the Bricktronics Shield
-  BricktronicsShield::begin();
 
   // Initialize the button connection
   b.begin();

--- a/examples/SimpleButton/SimpleButtonBricktronicsMegashield/SimpleButtonBricktronicsMegashield.ino
+++ b/examples/SimpleButton/SimpleButtonBricktronicsMegashield/SimpleButtonBricktronicsMegashield.ino
@@ -14,8 +14,6 @@
 //   https://github.com/wayneandlayne/BricktronicsButton
 // * Wayne and Layne BricktronicsMegashield library
 //   https://github.com/wayneandlayne/BricktronicsMegashield
-// * Adafruit MCP23017 library
-//   https://github.com/adafruit/Adafruit-MCP23017-Arduino-Library
 //
 // Written in 2016 by Matthew Beckler and Adam Wolf for Wayne and Layne, LLC
 // To the extent possible under law, the author(s) have dedicated all
@@ -26,8 +24,8 @@
 
 
 // Include the Bricktronics libraries
-#include <BricktronicsButton.h>
 #include <BricktronicsMegashield.h>
+#include <BricktronicsButton.h>
 
 
 // Select the desired sensor port (SENSOR_1 through SENSOR_4) in the constructor below.

--- a/examples/SimpleButton/SimpleButtonBricktronicsShield/SimpleButtonBricktronicsShield.ino
+++ b/examples/SimpleButton/SimpleButtonBricktronicsShield/SimpleButtonBricktronicsShield.ino
@@ -1,19 +1,19 @@
-// Bricktronics Example: SimpleButtonBricktronicsBreakoutBoard
+// Bricktronics Example: SimpleButtonBricktronicsShield
 // http://www.wayneandlayne.com/bricktronics
 //
 // This example queries the NXT pushbutton sensor and transmits "pressed" and
 // "released" over the serial port.
 //
 // Hardware used:
-// * Wayne and Layne Bricktronics Breakout Board
-//   https://store.wayneandlayne.com/products/bricktronics-breakout-board.html
+// * Wayne and Layne Bricktronics Shield
+//   https://store.wayneandlayne.com/products/bricktronics-shield-kit.html
 // * LEGO NXT Pushbutton sensor
 //
 // Software libraries used:
 // * Wayne and Layne BricktronicsButton library
 //   https://github.com/wayneandlayne/BricktronicsButton
-// * Adafruit MCP23017 library
-//   https://github.com/adafruit/Adafruit-MCP23017-Arduino-Library
+// * Wayne and Layne BricktronicsShield library
+//   https://github.com/wayneandlayne/BricktronicsShield
 //
 // Written in 2016 by Matthew Beckler and Adam Wolf for Wayne and Layne, LLC
 // To the extent possible under law, the author(s) have dedicated all
@@ -24,27 +24,22 @@
 
 
 // Include the Bricktronics libraries
+#include <BricktronicsShield.h>
 #include <BricktronicsButton.h>
 
 
-// Connect these pins on the Bricktronics Breakout board:
-//  Pin 1 - Connect to Arduino input pin (any digital input pin)
-//  Pin 2 - Connect to Ground
-//  Pin 3 - Connect to Ground
-//  Pin 4 - Connect to 5V
-//  Pin 5 - No connection
-//  Pin 6 - No connection
-//
-// The BricktronicsButton() argument is simply the Arduino pin where pin 1
-// on the breakout board is connected.
-//
-BricktronicsButton b(7);
+// Select the sensor port (SENSOR_1 through SENSOR_4) in the constructor below.
+// If your chosen sensor port has jumpers (ports 3 and 4), connect pins 2-3 and 4-5.
+BricktronicsButton b(BricktronicsShield::SENSOR_1);
 
 
 void setup()
 {
   // Be sure to set your serial console to 115200 baud
   Serial.begin(115200);
+
+  // Initialize the Bricktronics Shield
+  BricktronicsShield::begin();
 
   // Initialize the button connection
   b.begin();


### PR DESCRIPTION
Integrating external dependencies into the library itself. This simplifies installation for users, so they don't need to install any other libraries beyond the Bricktronics libraries.
